### PR TITLE
Best effort translation of lower('0xDEADBEEF') to just 0xDEADBEEF

### DIFF
--- a/dune/translate/helpers.py
+++ b/dune/translate/helpers.py
@@ -409,6 +409,15 @@ def fix_bytearray_param(query):
     return re.sub(pattern, r"{{\1}}", query, flags=re.IGNORECASE)
 
 
+def fix_bytearray_lower(query):
+    """Remove lower function call around '0x...' string literals, and remove the string since we have native hex types.
+
+    This has to happen after SQLGlot, since it will parse a bare 0x as a string literal"""
+    pattern = r"lower\(\s*['\"]0x(.*?)['\"]\s*\)"
+    substituted = re.sub(pattern, r"0x\1", query, flags=re.IGNORECASE)
+    return substituted
+
+
 def transforms(query_tree, dialect, dataset):
     """Apply several transforms to the query in order. Each transform takes and returns a sqlglot.Expression"""
     if dialect == "postgres":

--- a/dune/translate/translate.py
+++ b/dune/translate/translate.py
@@ -10,6 +10,7 @@ from dune.translate.helpers import (
     add_warnings_and_banner,
     transforms,
     fix_bytearray_param,
+    fix_bytearray_lower,
 )
 
 
@@ -34,6 +35,7 @@ def _translate_query_sqlglot(query, sqlglot_dialect, dataset=None):
         # Replace placeholders with Dune params again
         query = query.replace(quoted_param_left_placeholder, "{{").replace(quoted_param_right_placeholder, "}}")
         query = fix_bytearray_param(query)
+        query = fix_bytearray_lower(query)
 
         return add_warnings_and_banner(query)
     except ParseError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dune-query-translator"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = ["Vegard Stikbakke <vegard@dune.com>"]
 readme = "README.md"

--- a/tests/test_cases/bytea_lower.in
+++ b/tests/test_cases/bytea_lower.in
@@ -1,0 +1,1 @@
+select lower('0xfoo'), 'hello'

--- a/tests/test_cases/bytea_lower.out
+++ b/tests/test_cases/bytea_lower.out
@@ -1,0 +1,5 @@
+/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
+
+SELECT
+  0xfoo,
+  'hello'

--- a/tests/test_cases/matic.out
+++ b/tests/test_cases/matic.out
@@ -6,7 +6,7 @@ WITH transfers_to AS (
     SUM(TRY_CAST(CAST(value AS DOUBLE) AS DOUBLE)) / 1e18 AS amount
   FROM erc20_polygon.evt_Transfer
   WHERE
-    contract_address = LOWER('0xea1132120ddcdda2f119e99fa7a27a0d036f7ac9')
+    contract_address = 0xea1132120ddcdda2f119e99fa7a27a0d036f7ac9
   GROUP BY
     1
 ), transfers_from AS (
@@ -17,7 +17,7 @@ WITH transfers_to AS (
     ) * SUM(TRY_CAST(CAST(value AS DOUBLE) AS DOUBLE)) / 1e18 AS amount
   FROM erc20_polygon.evt_Transfer
   WHERE
-    contract_address = LOWER('0xea1132120ddcdda2f119e99fa7a27a0d036f7ac9')
+    contract_address = 0xea1132120ddcdda2f119e99fa7a27a0d036f7ac9
   GROUP BY
     1
 ), all_opers AS (
@@ -38,6 +38,6 @@ GROUP BY
   1
 HAVING
   SUM(CAST(amount AS DOUBLE)) >= 0.1
-  AND wallet <> LOWER('0x0000000000000000000000000000000000000000')
+  AND wallet <> 0x0000000000000000000000000000000000000000
 ORDER BY
   2 DESC

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -15,15 +15,18 @@ class Case:
 
 
 test_cases = [
+    # PostgreSQL
     Case("test_cases/dex.in", "test_cases/dex.out", "postgres", "ethereum"),
-    Case("test_cases/interval.in", "test_cases/interval.out", "spark", ""),
-    Case("test_cases/matic.in", "test_cases/matic.out", "spark", ""),
     Case("test_cases/param.in", "test_cases/param.out", "postgres", ""),
     Case("test_cases/aliases.in", "test_cases/aliases.out", "postgres", ""),
     Case("test_cases/now.in", "test_cases/now.out", "postgres", ""),
     Case("test_cases/bytea2numeric.in", "test_cases/bytea2numeric.out", "postgres", ""),
+    # Spark SQL
+    Case("test_cases/interval.in", "test_cases/interval.out", "spark", ""),
+    Case("test_cases/matic.in", "test_cases/matic.out", "spark", ""),
     Case("test_cases/bytea2numeric.in", "test_cases/bytea2numeric.out", "spark", ""),
     Case("test_cases/bytea_param.in", "test_cases/bytea_param.out", "spark", ""),
+    Case("test_cases/bytea_lower.in", "test_cases/bytea_lower.out", "spark", ""),
 ]
 
 


### PR DESCRIPTION
We want to translate `lower('0xDEADBEEF')` into `0xDEADBEEF` since we support hex types natively in DuneSQL, but they're not represented as strings, so they must be translated.