### PR TITLE
Fix Spark quoted columns

### DIFF
--- a/dune/translate/custom_transforms.py
+++ b/dune/translate/custom_transforms.py
@@ -223,7 +223,7 @@ def interval_fix(node):
                 "year",
             ]
         ):
-            if granularity.endswith('s'):
+            if granularity.endswith("s"):
                 granularity = granularity[:-1]
             if granularity == "week":  # we don't have week in Trino SQL
                 value = int(value) * 7

--- a/dune/translate/custom_transforms.py
+++ b/dune/translate/custom_transforms.py
@@ -414,7 +414,7 @@ def spark_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.
 
     Each transform takes and returns a sqlglot.Expression"""
-    query_tree = sqlglot.parse_one(query, read="trino")
+    query_tree = sqlglot.parse_one(query, read="spark")
     transforms = (
         interval_fix,
         fix_boolean,

--- a/dune/translate/custom_transforms.py
+++ b/dune/translate/custom_transforms.py
@@ -414,7 +414,7 @@ def spark_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.
 
     Each transform takes and returns a sqlglot.Expression"""
-    query_tree = sqlglot.parse_one(query, read="spark")
+    query_tree = sqlglot.parse_one(query, read="trino")
     transforms = (
         interval_fix,
         fix_boolean,

--- a/dune/translate/custom_transforms.py
+++ b/dune/translate/custom_transforms.py
@@ -19,7 +19,8 @@ def extract_nested_select(text):
                 end = i + 1
                 substring = text[stack[0] : end].strip()
                 stack = []  # reset the stack after an end is found
-                if re.search(r"^\(\s*select\b", substring, re.IGNORECASE):  # if substring starts with "(select " then
+                # if substring starts with "(select "
+                if re.search(r"^\(\s*select\b", substring, re.IGNORECASE):
                     results.append(substring)
     return results
 
@@ -113,9 +114,6 @@ def recurse_where(node, required_tables, condition_add):
     return statement
 
 
-# SQLGlot functions
-
-
 def chain_where_blockchain(node, blockchain):
     # add a blockchain = 'ethereum' to the WHERE statement for trades, tokens, and prices tables.
     required_tables = [
@@ -142,6 +140,7 @@ chain_where_polygon = partial(chain_where_blockchain, blockchain="polygon")
 
 
 def dex_trades_fixes(node):
+    """Fixes to dex.trades"""
     # doesn't matter if subquery or not, it will replace the found filter.
     if node.key == "select":
         if "dex.in.trades" in node.sql(dialect="trino").replace('"', ""):
@@ -192,7 +191,7 @@ single_quoted_param_left_placeholder = f"'{param_left_placeholder}"
 single_quoted_param_right_placeholder = f"{param_right_placeholder}'"
 
 
-# TODO: Remove this once https://github.com/tobymao/sqlglot/issues/1410 is fixed
+# TODO: Remove or simplify once the fix to https://github.com/tobymao/sqlglot/issues/1410 is released
 def interval_fix(node):
     """Handle interval syntax change from Spark to Trino"""
     if node.key == "interval":
@@ -208,8 +207,10 @@ def interval_fix(node):
         # no match, return
         if len(regex_matches) == 0:
             return node
-        identifier = " ".join(regex_matches)
-        value, granularity, *rest = identifier.split()
+        interval_argument = " ".join(regex_matches)
+        if len(interval_argument.split()) == 1:
+            return node
+        value, granularity, *rest = interval_argument.split()
         if any(
             known_granularity in granularity.lower()
             for known_granularity in [
@@ -222,7 +223,7 @@ def interval_fix(node):
                 "year",
             ]
         ):
-            if granularity[-1] == "s":
+            if granularity.endswith('s'):
                 granularity = granularity[:-1]
             if granularity == "week":  # we don't have week in Trino SQL
                 value = int(value) * 7
@@ -242,12 +243,12 @@ def bytearray_parameter_fix(node):
     if node.key == "eq":
         if all(
             a_param in node.sql(dialect="trino").lower()
-            for a_param in [
+            for a_param in (
                 "0x",
                 "substring(",
                 double_quoted_param_left_placeholder,
                 double_quoted_param_right_placeholder,
-            ]
+            )
         ):
             # include param_left variables in regex pattern
             pattern = (
@@ -268,7 +269,7 @@ def cast_numeric(node):
     """if a column is being added, subtracted, multiplied, divided, etc,
     and it has amount/value in the name, cast to double"""
     if node.key == "column":
-        if any(val in node.name.lower() for val in ["amount", "value"]):
+        if any(val in node.name.lower() for val in ("amount", "value")):
             return sqlglot.parse_one("cast(" + node.name + " as double)", read="trino")
     return node
 
@@ -294,7 +295,7 @@ def cast_timestamp(node):
 def fix_boolean(node):
     """If node.key is 'literal' and contains 'true' or 'false' then cast to boolean"""
     if node.key == "literal":
-        if any(boolean in node.sql(dialect="trino").lower() for boolean in ["true", "false"]):
+        if any(boolean in node.sql(dialect="trino").lower() for boolean in ("true", "false")):
             # remove single or double quotes
             bool_cleaned = node.sql(dialect="trino").replace('"', "").replace("'", "")
             return sqlglot.parse_one(bool_cleaned, read="trino")
@@ -385,7 +386,7 @@ def chain_where(dataset):
     }[dataset]
 
 
-def sqlglot_postgres_transforms(query, dataset):
+def postgres_transforms(query, dataset):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.
 
     Each transform takes and returns a sqlglot.Expression"""
@@ -409,11 +410,11 @@ def sqlglot_postgres_transforms(query, dataset):
     return query_tree
 
 
-def sqlglot_spark_transforms(query):
+def spark_transforms(query):
     """Apply a series of transforms to the query tree, recursively using SQLGlot's recursive transform function.
 
     Each transform takes and returns a sqlglot.Expression"""
-    query_tree = sqlglot.parse_one(query, read="spark")
+    query_tree = sqlglot.parse_one(query, read="trino")
     transforms = (
         interval_fix,
         fix_boolean,

--- a/dune/translate/translate.py
+++ b/dune/translate/translate.py
@@ -3,19 +3,19 @@ import re
 import sqlglot
 from sqlglot import ParseError
 
-from dune.translate.errors import DuneTranslationError
 from dune.translate.custom_transforms import (
     add_warnings_and_banner,
     double_quoted_param_left_placeholder,
     double_quoted_param_right_placeholder,
     fix_bytearray_lower,
     fix_bytearray_param,
+    postgres_transforms,
     prep_query,
     single_quoted_param_left_placeholder,
     single_quoted_param_right_placeholder,
-    postgres_transforms,
     spark_transforms,
 )
+from dune.translate.errors import DuneTranslationError
 
 
 def _clean_dataset(dataset):

--- a/dune/translate/translate.py
+++ b/dune/translate/translate.py
@@ -4,7 +4,7 @@ import sqlglot
 from sqlglot import ParseError
 
 from dune.translate.errors import DuneTranslationError
-from dune.translate.helpers import (
+from dune.translate.custom_transforms import (
     add_warnings_and_banner,
     double_quoted_param_left_placeholder,
     double_quoted_param_right_placeholder,
@@ -13,8 +13,8 @@ from dune.translate.helpers import (
     prep_query,
     single_quoted_param_left_placeholder,
     single_quoted_param_right_placeholder,
-    sqlglot_postgres_transforms,
-    sqlglot_spark_transforms,
+    postgres_transforms,
+    spark_transforms,
 )
 
 
@@ -39,11 +39,11 @@ def _translate_query(query, sqlglot_dialect, dataset=None):
 
         # Perform custom transformations using SQLGlot's parsed representation
         if sqlglot_dialect == "spark":
-            query_tree = sqlglot_spark_transforms(query)
+            query_tree = spark_transforms(query)
         elif sqlglot_dialect == "postgres":
             # Update bytearray syntax
             query = query.replace("\\x", "0x")
-            query_tree = sqlglot_postgres_transforms(query, dataset)
+            query_tree = postgres_transforms(query, dataset)
 
         # Turn back to SQL
         query = query_tree.sql(dialect="trino", pretty=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dune-query-translator"
-version = "0.3.1"
+version = "0.4.0"
 description = ""
 authors = ["Vegard Stikbakke <vegard@dune.com>"]
 readme = "README.md"

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -31,4 +31,5 @@ spark_test_cases = [
     SparkTestCase("test_cases/spark/bytea_param.in", "test_cases/spark/bytea_param.out"),
     SparkTestCase("test_cases/spark/bytea_lower.in", "test_cases/spark/bytea_lower.out"),
     SparkTestCase("test_cases/param.in", "test_cases/param.out"),
+    SparkTestCase("test_cases/spark/quoted_column.in", "test_cases/spark/quoted_column.out"),
 ]

--- a/tests/test_cases/spark/matic.out
+++ b/tests/test_cases/spark/matic.out
@@ -2,7 +2,7 @@
 
 WITH transfers_to AS (
   SELECT
-    'to' AS wallet,
+    "to" AS wallet,
     SUM(TRY_CAST(CAST(value AS DOUBLE) AS DOUBLE)) / 1e18 AS amount
   FROM erc20_polygon.evt_Transfer
   WHERE
@@ -11,7 +11,7 @@ WITH transfers_to AS (
     1
 ), transfers_from AS (
   SELECT
-    'from' AS wallet,
+    "from" AS wallet,
     (
       -1
     ) * SUM(TRY_CAST(CAST(value AS DOUBLE) AS DOUBLE)) / 1e18 AS amount

--- a/tests/test_cases/spark/quoted_column.in
+++ b/tests/test_cases/spark/quoted_column.in
@@ -1,0 +1,1 @@
+select `to` from foo

--- a/tests/test_cases/spark/quoted_column.out
+++ b/tests/test_cases/spark/quoted_column.out
@@ -1,0 +1,5 @@
+/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
+
+SELECT
+  "to"
+FROM foo

--- a/tests/update_expected_outputs.py
+++ b/tests/update_expected_outputs.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from dune.translate import migrate_spark, migrate_postgres
-from tests.cases import postgres_test_cases, SparkTestCase, PostgresTestCase, spark_test_cases
+from dune.translate import migrate_postgres, migrate_spark
+from tests.cases import PostgresTestCase, SparkTestCase, postgres_test_cases, spark_test_cases
 
 
 def update_test_case(tc):

--- a/tests/update_expected_outputs.py
+++ b/tests/update_expected_outputs.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from dune.translate.translate import migrate
-from tests.cases import postgres_test_cases
+from dune.translate import migrate_spark, migrate_postgres
+from tests.cases import postgres_test_cases, SparkTestCase, PostgresTestCase, spark_test_cases
 
 
 def update_test_case(tc):
@@ -11,11 +11,16 @@ def update_test_case(tc):
     out_filename = p / tc.out_filename
     with open(in_filename, "r") as f:
         query = f.read()
-    output = migrate(query, tc.dialect, tc.dataset)
+    if isinstance(tc, SparkTestCase):
+        output = migrate_spark(query)
+    elif isinstance(tc, PostgresTestCase):
+        output = migrate_postgres(query, tc.dataset)
     with open(out_filename, "w") as f:
         f.write(output)
 
 
 if __name__ == "__main__":
     for testcase in postgres_test_cases:
+        update_test_case(testcase)
+    for testcase in spark_test_cases:
         update_test_case(testcase)


### PR DESCRIPTION
If a Spark column is selected with a quote, it's currently incorrectly translated to a string.

e.g.

```
select `column` from table
```

becomes

```
select 'column' from table
```

This PR fixes that. The error was that for Spark queries, that we'd already transpiled to Trino, we were parsing them as Spark.