### PR TITLE
Add transform for interval '1' week -> interval '7' day

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dune-query-translator"
-version = "0.5.0"
+version = "0.6.0"
 description = ""
 authors = ["Vegard Stikbakke <vegard@dune.com>"]
 readme = "README.md"

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -33,4 +33,5 @@ spark_test_cases = [
     SparkTestCase("test_cases/param.in", "test_cases/param.out"),
     SparkTestCase("test_cases/spark/quoted_column.in", "test_cases/spark/quoted_column.out"),
     SparkTestCase("test_cases/spark/0x_strings.in", "test_cases/spark/0x_strings.out"),
+    SparkTestCase("test_cases/spark/interval_week.in", "test_cases/spark/interval_week.out"),
 ]

--- a/tests/test_cases/spark/interval_week.in
+++ b/tests/test_cases/spark/interval_week.in
@@ -1,0 +1,1 @@
+select now() - interval '64' week

--- a/tests/test_cases/spark/interval_week.out
+++ b/tests/test_cases/spark/interval_week.out
@@ -1,0 +1,4 @@
+/* Success! If you're still running into issues, check out https://dune.com/docs/query/syntax-differences/ or reach out in the #dune-sql Discord channel. */
+
+SELECT
+  CURRENT_TIMESTAMP - INTERVAL '448' day /* week doesn't work in DuneSQL */


### PR DESCRIPTION
Trino doesn't support week intervals. We have a transform working if the week is inside the value quotes, like `interval '1 week'`, but not if it's outside, like `interval '1' week`. This PR adds that.